### PR TITLE
Category 一覧表示、追加、更新、削除機能

### DIFF
--- a/app/controllers/CategoryController.scala
+++ b/app/controllers/CategoryController.scala
@@ -131,6 +131,23 @@ class CategoryController @Inject()(
         )
   }
 
-  def removeAction(id: Long): Action[AnyContent] = ???
+  def removeAction(id: Long): Action[AnyContent] = Action.async {
+    implicit req =>
+      CategoryRepository.get(Category.Id(id)).flatMap {
+        case None =>
+          Future.successful(
+            Redirect(routes.CategoryController.index())
+              .flashing("error" -> "削除対象のカテゴリーが見つかりませんでした"))
+        case Some(embeddedCategory) =>
+          CategoryRepository.remove(embeddedCategory.id).map { _ =>
+            Redirect(routes.CategoryController.index())
+              .flashing("success" -> "Categoryを削除しました")
+          } recover {
+            case _: Exception =>
+              Redirect(routes.CategoryController.index())
+                .flashing("error" -> "Categoryの削除に失敗しました")
+          }
+      }
+  }
 
 }

--- a/app/controllers/CategoryController.scala
+++ b/app/controllers/CategoryController.scala
@@ -26,10 +26,12 @@ class CategoryController @Inject()(
     jsSrc = Seq("main.js")
   )
 
-  private val optionsOfCategoryColor = CategoryColor.values.tail.map {
-    categoryColor =>
+  // CategoryColor.COLOR_OPTION_NONEはTodoにcategoryIdが設定されていない(categoryId=0)ときに使用するのため、selectフォーム用のoptionでは除いている
+  private val optionsOfCategoryColor = CategoryColor.values
+    .filterNot(_ == CategoryColor.COLOR_OPTION_NONE)
+    .map { categoryColor =>
       (categoryColor.code.toString, categoryColor.name)
-  }
+    }
 
   def index(): Action[AnyContent] = Action.async { implicit req =>
     val indexVv =

--- a/app/controllers/CategoryController.scala
+++ b/app/controllers/CategoryController.scala
@@ -1,0 +1,40 @@
+package controllers
+
+import lib.persistence.onMySQL.CategoryRepository
+
+import javax.inject._
+import play.api.mvc._
+import model.{ViewValueCategory, ViewValueHome}
+import service.CategoryService
+
+import scala.concurrent.Future
+import scala.concurrent.ExecutionContext.Implicits.global
+
+@Singleton
+class CategoryController @Inject()(val controllerComponents: ControllerComponents)
+  extends BaseController
+    with play.api.i18n.I18nSupport {
+
+  private val vv = ViewValueHome(
+    title = "Category",
+    cssSrc = Seq("uikit.min.css", "main.css"),
+    jsSrc = Seq("main.js")
+  )
+
+  def index(): Action[AnyContent] = Action.async { implicit req =>
+    CategoryService.getViewValueCategory.map { categories =>
+      Ok(views.html.category.Index(vv, categories))
+    }
+  }
+
+  def create: Action[AnyContent] = ???
+
+  def createAction: Action[AnyContent] = ???
+
+  def update(id: Long): Action[AnyContent] = ???
+
+  def updateAction(id: Long): Action[AnyContent] = ???
+
+  def removeAction(id: Long): Action[AnyContent] = ???
+
+}

--- a/app/controllers/TodoController.scala
+++ b/app/controllers/TodoController.scala
@@ -35,7 +35,7 @@ class TodoController @Inject()(val controllerComponents: ControllerComponents)
       jsSrc = Seq("uikit.min.js", "uikit-icons.min.js", "main.js")
     )
 
-    TodoService.getFutureSeqViewValueTodo.map { seqViewValueTodo =>
+    TodoService.getSeqViewValueTodo.map { seqViewValueTodo =>
       Ok(views.html.todo.Index(vv, seqViewValueTodo, todoForm))
     }
   }

--- a/app/forms/CategoryForm.scala
+++ b/app/forms/CategoryForm.scala
@@ -1,0 +1,60 @@
+package forms
+
+import lib.model.Category.CategoryColor
+import play.api.data._
+import play.api.data.Forms._
+import play.api.data.format.Formatter
+
+case class CategoryForm(
+  name: String,
+  slug: String,
+  categoryColor: CategoryColor
+)
+
+object CategoryForm {
+
+  implicit val categoryColorFormat: Formatter[CategoryColor] =
+    new Formatter[CategoryColor] {
+      override def bind(
+        key: String,
+        data: Map[String, String]): Either[Seq[FormError], CategoryColor] = {
+        data.get(key) match {
+          case Some(s) =>
+            try {
+              Right(
+                CategoryColor
+                  .find(_.code == s.toShort)
+                  .getOrElse(CategoryColor.COLOR_OPTION_NONE))
+            } catch {
+              case _: NumberFormatException =>
+                Left(Seq(FormError(key, "error.number", Nil)))
+            }
+          case None => Left(Seq(FormError(key, "error.required", Nil)))
+        }
+      }
+
+      override def unbind(
+        key: String,
+        value: CategoryColor
+      ): Map[String, String] =
+        Map(key -> value.toString)
+    }
+
+  val categoryForm: Form[CategoryForm] = Form(
+    mapping(
+      "name" -> nonEmptyText.verifying(
+        "カテゴリ名は英数字・日本語を入力することができ、改行を含むことができません",
+        name =>
+          name
+            .matches("[\\p{IsAlphabetic}\\p{IsDigit}\\p{IsIdeographic}]+") && !name
+            .contains("\n")
+      ),
+      "slug" -> nonEmptyText.verifying(
+        "英数字以外を入力することはできません",
+        slug => slug.matches("[a-zA-Z0-9]+") && !slug.contains("\n")
+      ),
+      "categoryColor" -> of[CategoryColor]
+    )(CategoryForm.apply)(CategoryForm.unapply)
+  )
+
+}

--- a/app/lib/model/Category.scala
+++ b/app/lib/model/Category.scala
@@ -25,9 +25,14 @@ object Category {
     val color: String
   ) extends EnumStatus
   object CategoryColor extends EnumStatus.Of[CategoryColor] {
-    case object COLOR_OPTION1 extends CategoryColor(code = 1, name = "赤", color = "#FF5722")
-    case object COLOR_OPTION2 extends CategoryColor(code = 2, name = "緑", color = "#4CAF50")
-    case object COLOR_OPTION3 extends CategoryColor(code = 3, name = "青", color = "#03A9F4")
+    case object COLOR_OPTION_NONE
+      extends CategoryColor(code = 0, name = "白", color = "#FFF")
+    case object COLOR_OPTION1
+      extends CategoryColor(code = 1, name = "赤", color = "#FF4500")
+    case object COLOR_OPTION2
+      extends CategoryColor(code = 2, name = "緑", color = "#4CAF50")
+    case object COLOR_OPTION3
+      extends CategoryColor(code = 3, name = "青", color = "#03A9F4")
   }
 
   def apply(

--- a/app/lib/model/Category.scala
+++ b/app/lib/model/Category.scala
@@ -26,7 +26,7 @@ object Category {
   ) extends EnumStatus
   object CategoryColor extends EnumStatus.Of[CategoryColor] {
     case object COLOR_OPTION_NONE
-      extends CategoryColor(code = 0, name = "白", color = "#FFF")
+      extends CategoryColor(code = 0, name = "灰", color = "#808080")
     case object COLOR_OPTION1
       extends CategoryColor(code = 1, name = "赤", color = "#FF4500")
     case object COLOR_OPTION2

--- a/app/model/Category.scala
+++ b/app/model/Category.scala
@@ -3,6 +3,7 @@ package model
 import lib.model.Category.CategoryColor
 
 case class ViewValueCategory (
+  id: Long,
   name: String,
   slug: String,
   colorCategory: CategoryColor

--- a/app/model/Category.scala
+++ b/app/model/Category.scala
@@ -1,0 +1,9 @@
+package model
+
+import lib.model.Category.CategoryColor
+
+case class ViewValueCategory (
+  name: String,
+  slug: String,
+  colorCategory: CategoryColor
+)

--- a/app/service/CategoryService.scala
+++ b/app/service/CategoryService.scala
@@ -1,6 +1,7 @@
 package service
 
 import lib.persistence.onMySQL.CategoryRepository
+import model.ViewValueCategory
 
 import scala.concurrent.Future
 import scala.concurrent.ExecutionContext.Implicits.global
@@ -8,12 +9,24 @@ import scala.concurrent.ExecutionContext.Implicits.global
 object CategoryService {
 
   /**
-    * Formのselectボックスで使用する値を返す
-    */
+   * Formのselectボックスで使用する値を返す
+   */
   def getOptionsOfCategory: Future[Seq[(String, String)]] = {
     CategoryRepository.getAll.map { seqCategories =>
       seqCategories.map { category =>
         (category.id.toString, category.v.name)
+      }
+    }
+  }
+
+  def getViewValueCategory: Future[Seq[ViewValueCategory]] = {
+    CategoryRepository.getAll.map { seqCategory =>
+      seqCategory.map { category =>
+        ViewValueCategory(
+          name = category.v.name,
+          slug = category.v.slug,
+          colorCategory = category.v.categoryColor
+        )
       }
     }
   }

--- a/app/service/CategoryService.scala
+++ b/app/service/CategoryService.scala
@@ -23,6 +23,7 @@ object CategoryService {
     CategoryRepository.getAll.map { seqCategory =>
       seqCategory.map { category =>
         ViewValueCategory(
+          id = category.id,
           name = category.v.name,
           slug = category.v.slug,
           colorCategory = category.v.categoryColor

--- a/app/service/TodoService.scala
+++ b/app/service/TodoService.scala
@@ -1,5 +1,6 @@
 package service
 
+import lib.model.Category.CategoryColor
 import lib.persistence.onMySQL.{CategoryRepository, TodoRepository}
 import model.ViewValueTodo
 
@@ -11,19 +12,19 @@ object TodoService {
   def getSeqViewValueTodo: Future[Seq[ViewValueTodo]] = {
     (TodoRepository.getAll zip CategoryRepository.getAll).map {
       case (todos, categories) =>
-        todos.flatMap { embeddedTodo =>
+        todos.map { embeddedTodo =>
           val todo = embeddedTodo.v
           val optCategory = categories.find(_.id == todo.categoryId).map(_.v)
-          optCategory.map { category =>
-            ViewValueTodo(
-              id = embeddedTodo.id,
-              title = todo.title,
-              body = todo.body,
-              status = todo.state,
-              categoryName = category.name,
-              categoryColor = category.categoryColor
-            )
-          }
+          ViewValueTodo(
+            id = embeddedTodo.id,
+            title = todo.title,
+            body = todo.body,
+            status = todo.state,
+            categoryName = optCategory.map(_.name).getOrElse("カテゴリなし"),
+            categoryColor = optCategory
+              .map(_.categoryColor)
+              .getOrElse(CategoryColor.COLOR_OPTION_NONE)
+          )
         }
     }
   }

--- a/app/service/TodoService.scala
+++ b/app/service/TodoService.scala
@@ -8,7 +8,7 @@ import scala.concurrent.ExecutionContext.Implicits.global
 
 object TodoService {
 
-  def getFutureSeqViewValueTodo: Future[Seq[ViewValueTodo]] = {
+  def getSeqViewValueTodo: Future[Seq[ViewValueTodo]] = {
     (TodoRepository.getAll zip CategoryRepository.getAll).map {
       case (todos, categories) =>
         todos.flatMap { embeddedTodo =>

--- a/app/service/TodoService.scala
+++ b/app/service/TodoService.scala
@@ -1,5 +1,6 @@
 package service
 
+import lib.model.Category
 import lib.model.Category.CategoryColor
 import lib.persistence.onMySQL.{CategoryRepository, TodoRepository}
 import model.ViewValueTodo
@@ -26,6 +27,18 @@ object TodoService {
               .getOrElse(CategoryColor.COLOR_OPTION_NONE)
           )
         }
+    }
+  }
+
+  /**
+    * Categoryを削除した際、どのカテゴリーにも紐づいていないことを表すためにcategoryIdを0に変更する
+    */
+  def updateTodosOfNoneCategory(categoryId: Category.Id): Future[Int] = {
+    TodoRepository.getAllFilteredByCategoryId(categoryId).flatMap { seqEmbeddedTodo =>
+      val seqUpdatedTodo = seqEmbeddedTodo.map {
+        _.map(_.copy(categoryId = Category.Id(0)))
+      }
+      TodoRepository.bulkUpdate(seqUpdatedTodo)
     }
   }
 

--- a/app/views/category/Create.scala.html
+++ b/app/views/category/Create.scala.html
@@ -1,0 +1,14 @@
+@import helper._
+@import forms.CategoryForm
+
+@(vv: model.ViewValueCommon, categoryForm: Form[CategoryForm], optionsOfCategoryColor: Seq[(String, String)])(implicit req: RequestHeader, message: Messages, flash: Flash)
+
+@common.Default(vv){
+    @form(routes.CategoryController.createAction) {
+        @CSRF.formField
+        @inputText(categoryForm("name"), 'class -> "uk-input form-width")
+        @inputText(categoryForm("slug"), 'class -> "uk-input form-width")
+        @select(field = categoryForm("categoryColor"), options = optionsOfCategoryColor, 'class -> "uk-select form-width")
+        <input type="submit" class="uk-button uk-button-default bg-white">
+    }
+}

--- a/app/views/category/Index.scala.html
+++ b/app/views/category/Index.scala.html
@@ -21,8 +21,13 @@
                         <td>@category.name</td>
                         <td>@category.slug</td>
                         <td style="background-color: @category.colorCategory.color; color: #fff;">@category.colorCategory.name</td>
-                        <td>
+                        <td class="uk-flex" style="justify-content: end;">
                             <a href="@routes.CategoryController.update(category.id)" uk-icon="icon: file-edit; ratio: 1.2" class="a-hover-none uk-padding-small"></a>
+                            @form(routes.CategoryController.removeAction(category.id), 'onSubmit -> s"return confirmFormSubmit(event, '${category.name}')") {
+                                @CSRF.formField
+                                <input type="hidden" name="_method" value="DELETE">
+                                <button id="btn-@category.id" type="submit" uk-icon="icon: trash; ratio: 1.2" class="uk-padding-small"></button>
+                            }
                         </td>
                     </tr>
                 }

--- a/app/views/category/Index.scala.html
+++ b/app/views/category/Index.scala.html
@@ -12,6 +12,7 @@
                     <th>name</th>
                     <th>slug</th>
                     <th>color</th>
+                    <th></th>
                 </tr>
             </thead>
             <tbody>
@@ -20,6 +21,9 @@
                         <td>@category.name</td>
                         <td>@category.slug</td>
                         <td style="background-color: @category.colorCategory.color; color: #fff;">@category.colorCategory.name</td>
+                        <td>
+                            <a href="@routes.CategoryController.update(category.id)" uk-icon="icon: file-edit; ratio: 1.2" class="a-hover-none uk-padding-small"></a>
+                        </td>
                     </tr>
                 }
             </tbody>

--- a/app/views/category/Index.scala.html
+++ b/app/views/category/Index.scala.html
@@ -1,0 +1,22 @@
+@import helper._
+
+@(vv: model.ViewValueCommon, categories: Seq[model.ViewValueCategory])(implicit req: RequestHeader, message: Messages, flash: Flash)
+
+@common.Default(vv){
+    <div class="uk-text-right uk-margin-bottom">
+        <a href="/category/create" >+新規作成</a>
+    </div>
+    @for(category <- categories) {
+        <p>@category.name</p>
+    }
+}
+
+<script>
+function confirmFormSubmit(event, title) {
+  if (confirm(`${title}を削除しますか`)) {
+    return true;
+  } else {
+    return false;
+  }
+}
+</script>

--- a/app/views/category/Index.scala.html
+++ b/app/views/category/Index.scala.html
@@ -6,9 +6,24 @@
     <div class="uk-text-right uk-margin-bottom">
         <a href="/category/create" >+新規作成</a>
     </div>
-    @for(category <- categories) {
-        <p>@category.name</p>
-    }
+        <table class="uk-table uk-table-divider" style="background-color: #fff;">
+            <thead>
+                <tr>
+                    <th>name</th>
+                    <th>slug</th>
+                    <th>color</th>
+                </tr>
+            </thead>
+            <tbody>
+                @for(category <- categories) {
+                    <tr>
+                        <td>@category.name</td>
+                        <td>@category.slug</td>
+                        <td style="background-color: @category.colorCategory.color; color: #fff;">@category.colorCategory.name</td>
+                    </tr>
+                }
+            </tbody>
+        </table>
 }
 
 <script>

--- a/app/views/category/Update.scala.html
+++ b/app/views/category/Update.scala.html
@@ -1,0 +1,14 @@
+@import helper._
+@import forms.CategoryForm
+
+@(vv: model.ViewValueCommon, categoryId: Long, categoryForm: Form[CategoryForm], optionsOfCategoryColor: Seq[(String, String)])(implicit req: RequestHeader, message: Messages, flash: Flash)
+
+@common.Default(vv){
+    @form(routes.CategoryController.updateAction(categoryId)) {
+        @CSRF.formField
+        @inputText(categoryForm("name"), 'class -> "uk-input form-width")
+        @inputText(categoryForm("slug"), 'class -> "uk-input form-width")
+        @select(field = categoryForm("categoryColor"), options = optionsOfCategoryColor, 'class -> "uk-select form-width")
+        <input type="submit" class="uk-button uk-button-default bg-white">
+    }
+}

--- a/app/views/common/Default.scala.html
+++ b/app/views/common/Default.scala.html
@@ -18,8 +18,12 @@
   <body>
     @* And here's where we render the `Html` object containing
     * the page content. *@
-    <header class="header container">
-      <div class="header__content"><span class="header__logo">To-do Sample</span></div>
+    <header class="header container uk-flex uk-flex-middle uk-flex-between">
+      <div class="header-left"><span class="header__logo">To-do Sample</span></div>
+      <ul class="header-right uk-flex uk-flex-between">
+        <li><a href="/todo" class="uk-margin-small-right">Todo</a></li>
+        <li><a href="/category">Category</a></li>
+      </ul>
     </header>
     <main class="h-100vh bg-gray container">
       @flash.get("success").map { message =>

--- a/app/views/common/Default.scala.html
+++ b/app/views/common/Default.scala.html
@@ -18,22 +18,26 @@
   <body>
     @* And here's where we render the `Html` object containing
     * the page content. *@
-    <header class="header container uk-flex uk-flex-middle uk-flex-between">
-      <div class="header-left"><span class="header__logo">To-do Sample</span></div>
-      <ul class="header-right uk-flex uk-flex-between">
-        <li><a href="/todo" class="uk-margin-small-right">Todo</a></li>
-        <li><a href="/category">Category</a></li>
-      </ul>
+    <header class="header">
+      <div class="container w-800 uk-flex uk-flex-middle uk-flex-between">
+        <div class="header-left"><span class="header__logo">To-do Sample</span></div>
+        <ul class="header-right uk-flex uk-flex-between">
+          <li><a href="/todo" class="uk-margin-small-right">Todo</a></li>
+          <li><a href="/category">Category</a></li>
+        </ul>
+      </div>
     </header>
     <main class="h-100vh bg-gray container">
-      <h1>@vv.title</h1>
-      @flash.get("success").map { message =>
+      <div class="w-800">
+        <h1>@vv.title</h1>
+        @flash.get("success").map { message =>
         <span class="success-message">@message</span>
-      }
-      @flash.get("error").map { message =>
+        }
+        @flash.get("error").map { message =>
         <span class="error-message">@message</span>
-      }
-      @content
+        }
+        @content
+      </div>
     </main>
     @for(js <- vv.jsSrc) {
       <script src="@{routes.Assets.versioned("javascripts/" + js)}" type="text/javascript"></script>

--- a/app/views/common/Default.scala.html
+++ b/app/views/common/Default.scala.html
@@ -26,6 +26,7 @@
       </ul>
     </header>
     <main class="h-100vh bg-gray container">
+      <h1>@vv.title</h1>
       @flash.get("success").map { message =>
         <span class="success-message">@message</span>
       }

--- a/app/views/todo/Create.scala.html
+++ b/app/views/todo/Create.scala.html
@@ -1,14 +1,14 @@
 @import helper._
-@import requests.TodoForm
+@import forms.TodoForm
 
-@(vv: model.ViewValueCommon, todoForm: Form[TodoForm], optionsOfCategoryId: Seq[(String, String)], optionsOfTodoStatus: Seq[(String, String)])(implicit req: RequestHeader, message: Messages, flash: Flash)
+@(vv: model.ViewValueCommon, todoForm: Form[TodoForm], optionsOfCategoryColor: Seq[(String, String)], optionsOfTodoStatus: Seq[(String, String)])(implicit req: RequestHeader, message: Messages, flash: Flash)
 
 @common.Default(vv){
     @form(routes.TodoController.createAction) {
         @CSRF.formField
         @inputText(todoForm("title"), 'class -> "uk-input form-width")
         @textarea(todoForm("body"), 'class -> "uk-textarea form-width")
-        @select(field = todoForm("categoryId"), options = optionsOfCategoryId, 'class -> "uk-select form-width")
+        @select(field = todoForm("categoryId"), options = optionsOfCategoryColor, 'class -> "uk-select form-width")
         @select(field = todoForm("state"), options = optionsOfTodoStatus, 'class -> "uk-select form-width", 'readonly -> "readonly", 'style -> "pointer-events: none; background-color: gray", 'tabindex -> "-1")
         <input type="submit" class="uk-button uk-button-default bg-white">
     }

--- a/app/views/todo/Index.scala.html
+++ b/app/views/todo/Index.scala.html
@@ -1,5 +1,5 @@
 @import helper._
-@import requests.TodoForm
+@import forms.TodoForm
 
 @(vv: model.ViewValueCommon, todos: Seq[model.ViewValueTodo], todoForm: Form[TodoForm])(implicit req: RequestHeader, message: Messages, flash: Flash)
 

--- a/app/views/todo/Update.scala.html
+++ b/app/views/todo/Update.scala.html
@@ -1,5 +1,5 @@
 @import helper._
-@import requests.TodoForm
+@import forms.TodoForm
 
 @(vv: model.ViewValueCommon, todoForm: Form[TodoForm], preTodoId: Long, optionsOfCategoryId: Seq[(String, String)], optionsOfTodoStatus: Seq[(String, String)])(implicit req: RequestHeader, message: Messages, flash: Flash)
 

--- a/conf/routes
+++ b/conf/routes
@@ -9,6 +9,8 @@ POST /todo/update/:id controllers.TodoController.updateAction(id: Long)
 POST /todo/delete/:id controllers.TodoController.removeAction(id: Long)
 
 GET /category controllers.CategoryController.index
+GET /category/create controllers.CategoryController.create
+POST /category/create controllers.CategoryController.createAction
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/routes
+++ b/conf/routes
@@ -1,11 +1,14 @@
 
 GET / controllers.HomeController.index
+
 GET /todo controllers.TodoController.index
 GET /todo/create controllers.TodoController.create
 POST /todo/create controllers.TodoController.createAction
 GET /todo/update/:id controllers.TodoController.update(id: Long)
 POST /todo/update/:id controllers.TodoController.updateAction(id: Long)
 POST /todo/delete/:id controllers.TodoController.removeAction(id: Long)
+
+GET /category controllers.CategoryController.index
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/routes
+++ b/conf/routes
@@ -13,6 +13,7 @@ GET /category/create controllers.CategoryController.create
 POST /category/create controllers.CategoryController.createAction
 GET /category/update/:id controllers.CategoryController.update(id: Long)
 POST /category/update/:id controllers.CategoryController.updateAction(id: Long)
+POST /category/delete/:id controllers.CategoryController.removeAction(id: Long)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file controllers.Assets.versioned(path="/public", file: Asset)

--- a/conf/routes
+++ b/conf/routes
@@ -11,6 +11,8 @@ POST /todo/delete/:id controllers.TodoController.removeAction(id: Long)
 GET /category controllers.CategoryController.index
 GET /category/create controllers.CategoryController.create
 POST /category/create controllers.CategoryController.createAction
+GET /category/update/:id controllers.CategoryController.update(id: Long)
+POST /category/update/:id controllers.CategoryController.updateAction(id: Long)
 
 # Map static resources from the /public folder to the /assets URL path
 GET /assets/*file controllers.Assets.versioned(path="/public", file: Asset)

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -44,7 +44,8 @@ body {
 
 /* layout */
 .h-100vh {
-  height: 100vh;
+  min-height: 100vh;
+  height: 100%;
 }
 .container {
   padding: 16px 16px;

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -50,6 +50,10 @@ body {
 .container {
   padding: 16px 16px;
 }
+.w-800 {
+  max-width: 800px;
+  margin: auto;
+}
 
 /* backgroud color */
 .bg-white {

--- a/public/stylesheets/main.css
+++ b/public/stylesheets/main.css
@@ -7,16 +7,20 @@ body {
   padding:  0;
 }
 
+/* header */
 .header {
   height:            70px;
   background-color:  #24292F;
 }
-
 .header .header__logo {
   color:             white;
   line-height:       70px;
   font-size:         20px;
   font-weight:       bold;
+}
+.header-right a {
+  color: #fff;
+  text-decoration: underline;
 }
 
 .main {
@@ -100,4 +104,12 @@ a.a-hover-none {
   color: red;
   font-weight: bold;
   padding: 6px 12px;
+}
+
+/* li */
+ul {
+  padding-left: 0;
+}
+li {
+  list-style: none;
 }


### PR DESCRIPTION
## 要件

### Categoryの一覧表示機能について 
- Categoryを全件表示すること
- Categoryのデータが表示されていること(カテゴリ名, slug, 色) 
- カテゴリ名は英数字・日本語を入力することができ、改行を含むことができない
- slugは英数字のみ入力することができ、改行を含むことができない

### Categoryの追加機能について
- Categoryを新規で追加できること
- 以下のデータを入力・選択できるようになっていること
  - カテゴリ名, slug, 色
  - すべての入力項目は必須とする
  - slugには英数字以外は入れられない様にする

### Categoryの更新機能について
- Categoryを更新できること
- 以下のデータを入力・選択できるようになっていること
  - カテゴリ名, slug, 色 
  - 全ての入力項目は必須とする
  - 入力フォームはあらかじめ更新する内容のデータで埋まってる様にする

### Categoryの削除機能について
- Categoryを削除できること
- Category削除時にそのCategoryに該当するTodoのデータも更新する
  - どのカテゴリにも紐づいていない”というデータになるようTodoを更新する
    (Categoryの削除後に、紐づいているTodoのcategoryIdが0になるようにしました)

